### PR TITLE
Add "smarter" copying of code block snippets

### DIFF
--- a/src/part1/intro/conventions.md
+++ b/src/part1/intro/conventions.md
@@ -22,13 +22,24 @@ Examples such as this one are readily copied and may be pasted without edit into
 
 For interactive code, we display the default LFE prompt the reader will see when in the REPL. We also separate out input and output into separate code blocks. For example:
 
-```lisp 
+```lisp
 lfe> (integer_to_list 42 2)
 ```
-```lisp
+```text
 "101010"
 ```
-Note, however, that due to the inclusion of the `lfe>` prompt, care must be taken when copying and pasting these examples. If you copy these, you will almost certainly want to edit the pasted text to remove the prompt.
+
+For shell commands, the commands to enter at the prompt are prefixed by a `$` for the prompt.  Input and any relevant output are also separated out into distinct blocks.
+
+```shell
+$ echo "I am excited to learn LFE"
+```
+```text
+I am excited to learn LFE
+```
+
+Note, however, that due to the inclusion of the `lfe>` or `$` prompts, care must be taken when copying and pasting these examples. If you copy these using the copy buttons in the code blocks the prompts will be removed for you, otherwise, you will almost certainly want to edit the pasted text to remove the prompt.
+
 
 ## LiffyBot
 

--- a/src/part1/intro/guessing-game/README.md
+++ b/src/part1/intro/guessing-game/README.md
@@ -5,13 +5,13 @@ Now that you've seen some LFE in action, let's do something completely insane: w
 We will follow the same patterns established in the Hello-World examples, so if you are still in one of the Hello-World projects, change directory and then create a new LFE project:
 
 ```shell
-cd ../
-rebar3 new lfe-app guessing-game
-cd ./guessing-game
+$ cd ../
+$ rebar3 new lfe-app guessing-game
+$ cd ./guessing-game
 ```
 
 We will create this game by exploring functions in the REPL and then saving the results in a file. Open up your generated project in your favourite code-editing application, and then open up a terminal from your new project directory, and start the REPL:
 
 ```shell
-rebar3 lfe repl
+$ rebar3 lfe repl
 ```

--- a/src/part1/intro/guessing-game/play.md
+++ b/src/part1/intro/guessing-game/play.md
@@ -1,9 +1,9 @@
-# Plyaign the Game
+# Playing the Game
 
 If you are still in the REPL, quit out of it so that `rebar3` can rebuild out changed module. Then start it up again:
 
 ```shell
-rebar3 lfe repl
+$ rebar3 lfe repl
 ```
 
 Once at the LFE propmpt, start up the application:

--- a/src/part1/intro/hw/main.md
+++ b/src/part1/intro/hw/main.md
@@ -3,14 +3,14 @@
 From your system shell prompt, run the following to create a new project that will let us run a Hello-World program from the command line:
 
 ```shell
-rebar3 new lfe-main hello-world
-cd ./hello-world
+$ rebar3 new lfe-main hello-world
+$ cd ./hello-world
 ```
 
 Once in the project directory, you can actually just do this:
 
 ```shell
-rebar3 lfe run
+$ rebar3 lfe run
 ```
 
 You will see code getting downloaded and compiled, and then your script will run, generating the following output:
@@ -41,7 +41,7 @@ The other code that was created when we executed `rebar3 new lfe-main hello-worl
 You may be wondering about the `args` argument to the `main` function, and the fact that the printed output for the `args` when we ran this was `[]`. Let's try something:
 
 ```shell
-rebar3 lfe run -- Fenchurch 42
+$ rebar3 lfe run -- Fenchurch 42
 ```
 
 ```text

--- a/src/part1/intro/hw/otp.md
+++ b/src/part1/intro/hw/otp.md
@@ -9,20 +9,20 @@ As such, a _real_ Hello-World in LFE would be honest and let the prospective dev
 If you are still in the directory of the previous Hello-World project, let's get out of that:
 
 ```shell
-cd ../
+$ cd ../
 ```
 
 Now we're going to create a new project, one utilising the some very basic OTP patterns:
 
 ```shell
-rebar3 new lfe-app hello-otp-world
-cd ./hello-otp-world
+$ rebar3 new lfe-app hello-otp-world
+$ cd ./hello-otp-world
 ```
 
 We won't look at the code for this right now, since there are chapters dedicated to that in the second half of the book. But let's brush the surface with a quick run in the REPL:
 
 ```shell
-rebar3 lfe repl
+$ rebar3 lfe repl
 ```
 
 To start your new hello-world application, use the OTP `application` module:

--- a/src/part1/intro/hw/repl.md
+++ b/src/part1/intro/hw/repl.md
@@ -3,7 +3,7 @@
 As previously demonstrated, it is possible to start up the LFE read-eval-print-loop (REPL) using `rebar3`:
 
 ```shell
-rebar3 lfe repl
+$ rebar3 lfe repl
 ```
 
 Once you are at the LFE prompt, you may write a simple LFE "program" like the following:

--- a/src/part1/intro/setup.md
+++ b/src/part1/intro/setup.md
@@ -6,8 +6,8 @@ Having followed the notes and linked instructions in the [Prerequisites](prereq.
 First, unless you have configured other `rebar3` plugins on your system, you will need to create the configuration directory and the configuration file:
 
 ```shell
-mkdir ~/.config/rebar3
-touch ~/.config/rebar3/rebar.config
+$ mkdir ~/.config/rebar3
+$ touch ~/.config/rebar3/rebar.config
 ```
 
 Next, open up that file in your favourite editor, and give it these contents:
@@ -49,7 +49,7 @@ In particular, starting a REPL in Windows can take a little more effort (an extr
 With the LFE `rebar3` plugin successfully configured, you should be able to start up the LFE REPL anywhere on your system with the following:
 
 ```shell
-rebar3 lfe repl
+$ rebar3 lfe repl
 ```
 ```text
 Erlang/OTP 23 [erts-11.0] [source] [64-bit] [smp:16:16] [ds:16:16:10] [async-threads:1] [hipe]

--- a/theme/book.js
+++ b/theme/book.js
@@ -201,7 +201,7 @@ function playground_text(playground) {
     });
 
     if (window.playground_copyable) {
-        Array.from(document.querySelectorAll('pre code')).forEach(function (block) {
+        Array.from(document.querySelectorAll('pre code:not(.plaintext)')).forEach(function (block) {
             var pre_block = block.parentNode;
             if (!pre_block.classList.contains('playground')) {
                 var buttons = pre_block.querySelector(".buttons");
@@ -559,6 +559,18 @@ function playground_text(playground) {
 (function clipboard() {
     var clipButtons = document.querySelectorAll('.clip-button');
 
+    function removePrompts(text) {
+        return text.replaceAll(/^lfe> /mg, '').
+                    replaceAll(/^\$ /mg, '');
+    }
+
+    function removeResultsComments(text) {
+        return text.replaceAll(/^;; .*$/mg, '').
+                    replaceAll(/^# .*$/mg, '').
+                    replaceAll(/^(\r\n|\n)$/mg, '');
+
+    }
+
     function hideTooltip(elem) {
         elem.firstChild.innerText = "";
         elem.className = 'fa fa-copy clip-button';
@@ -573,7 +585,9 @@ function playground_text(playground) {
         text: function (trigger) {
             hideTooltip(trigger);
             let playground = trigger.closest("pre");
-            return playground_text(playground);
+            return removeResultsComments(
+                removePrompts(
+                  playground_text(playground)));
         }
     });
 


### PR DESCRIPTION
Filter out the prompts from the code blocks so that the user
does not have to when copying using the copy buttons.

Remove the `lfe> ` and `$ ` that are prompts by seeing if they
are at the very beginning of the line.

Removed the copy buttons from the pure text blocks that
represent the results of shell commands or LFE expressions.

Also removed lines that start with LFE and Bash comments from
the snippet text if it is decided that the output should be
shown in the same block for scenarios like the guessing game,
where it might be convienent for multiple expressions to be copied
as a single chunk of text.