### PR TITLE
docs: update rebar3_lfe plugin version to 0.4.11

### DIFF
--- a/src/part1/intro/setup.md
+++ b/src/part1/intro/setup.md
@@ -14,7 +14,7 @@ Next, open up that file in your favourite editor, and give it these contents:
 
 ```erlang
 {plugins, [
-  {rebar3_lfe, "0.4.8"}
+  {rebar3_lfe, "0.4.11"}
 ]}.
 ```
 


### PR DESCRIPTION
Summary:
Updated the rebar3_lfe plugin version from "0.4.8" to "0.4.11" in the example configuration.
