### PR TITLE
rebar3_lfe plugin version is a tad out of date, bumping `0.4.8` -> `0.5.5`

### DIFF
--- a/src/part1/intro/setup.md
+++ b/src/part1/intro/setup.md
@@ -14,7 +14,11 @@ Next, open up that file in your favourite editor, and give it these contents:
 
 ```erlang
 {plugins, [
-  {rebar3_lfe, "0.4.8"}
+  {rebar3_lfe, "0.5.5"}
+]}.
+
+{deps, [
+  {lfe, "2.2.0"}
 ]}.
 ```
 


### PR DESCRIPTION
Just tried walking through these instructions and ran into some very odd katana code and `rebar3_lint` plugin errors. Went to see if I was update to date and there was a distinct difference in the versions for the `rebar3_lfe` plugin. 

Updated the version and everything was happy. Not sure if anyone else has encountered this. :)